### PR TITLE
Add public chart button to landing page

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -36,6 +36,12 @@ export default function HomePage() {
         >
           Log in instead
         </Link>
+        <Link
+          href="/chart"
+          className="rounded-xl border border-slate-800 px-6 py-3 text-base font-medium text-slate-200 transition hover:bg-slate-900"
+        >
+          View the public chart
+        </Link>
       </div>
       <div className="rounded-2xl border border-slate-800 bg-slate-900/50 p-6 text-left shadow-lg">
         <h2 className="text-lg font-medium text-slate-200">Why The Chart 2.0?</h2>


### PR DESCRIPTION
## Summary
- add a new link on the landing page to open the public relationship chart

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4200df26483278a15431741555575