### PR TITLE
Add Supabase client configuration

### DIFF
--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,16 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl) {
+  throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL environment variable');
+}
+
+if (!supabaseAnonKey) {
+  throw new Error('Missing NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+export type SupabaseClient = typeof supabase;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "thechart2.0",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.45.4",
         "next": "15.5.4",
         "react": "19.1.0",
         "react-dom": "19.1.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.45.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "next": "15.5.4",


### PR DESCRIPTION
## Summary
- add the `@supabase/supabase-js` dependency to the project
- create a reusable Supabase client that checks for required environment variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d42267513483279507b82618f9d3fd