### PR TITLE
Fetch chart data from Supabase

### DIFF
--- a/app/chart/page.jsx
+++ b/app/chart/page.jsx
@@ -1,15 +1,14 @@
-import fs from "node:fs/promises";
-import path from "node:path";
 import ChartClient from "./ChartClient";
+import { getChartData } from "@/lib/supabase";
 
 export const metadata = {
   title: "Relationship Chart | The Chart 2.0",
 };
 
+export const revalidate = 0;
+
 export default async function ChartPage() {
-  const filePath = path.join(process.cwd(), "data", "chart.json");
-  const file = await fs.readFile(filePath, "utf-8");
-  const chartData = JSON.parse(file);
+  const chartData = await getChartData();
 
   return (
     <div className="space-y-6">

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,0 +1,56 @@
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!SUPABASE_URL) {
+  throw new Error("NEXT_PUBLIC_SUPABASE_URL is not defined");
+}
+
+if (!SUPABASE_ANON_KEY) {
+  throw new Error("NEXT_PUBLIC_SUPABASE_ANON_KEY is not defined");
+}
+
+async function fetchSupabase(endpoint, params = {}) {
+  const url = new URL(`/rest/v1/${endpoint}`, SUPABASE_URL);
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.set(key, value);
+  });
+
+  const response = await fetch(url, {
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+      Accept: "application/json",
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Supabase request failed for ${endpoint}: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export async function getChartData() {
+  const [nodeRows, linkRows] = await Promise.all([
+    fetchSupabase("nodes", { select: "name,group_type" }),
+    fetchSupabase("links", { select: "source,target,type" }),
+  ]);
+
+  const nodes = nodeRows
+    .filter((row) => row?.name && row?.group_type)
+    .map((row) => ({
+      id: row.name,
+      group: row.group_type,
+    }));
+
+  const links = linkRows
+    .filter((row) => row?.source && row?.target && row?.type)
+    .map((row) => ({
+      source: row.source,
+      target: row.target,
+      type: row.type,
+    }));
+
+  return { nodes, links };
+}


### PR DESCRIPTION
## Summary
- replace the local chart.json dependency with a Supabase-backed data fetch for the relationship chart page
- add a Supabase helper that queries the nodes and links tables and maps them into the react-force-graph shape
- disable ISR for the chart page so it always reflects the live Supabase data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d422df3a1c8327b710388d1312f4a6