### PR TITLE
Handle missing Supabase env vars

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,15 +1,15 @@
+import fallbackChartData from "@/data/chart.json";
+
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-if (!SUPABASE_URL) {
-  throw new Error("NEXT_PUBLIC_SUPABASE_URL is not defined");
-}
-
-if (!SUPABASE_ANON_KEY) {
-  throw new Error("NEXT_PUBLIC_SUPABASE_ANON_KEY is not defined");
-}
+const hasSupabaseCredentials = Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
 
 async function fetchSupabase(endpoint, params = {}) {
+  if (!hasSupabaseCredentials) {
+    throw new Error("Supabase credentials are not configured");
+  }
+
   const url = new URL(`/rest/v1/${endpoint}`, SUPABASE_URL);
   Object.entries(params).forEach(([key, value]) => {
     url.searchParams.set(key, value);
@@ -32,6 +32,19 @@ async function fetchSupabase(endpoint, params = {}) {
 }
 
 export async function getChartData() {
+  if (!hasSupabaseCredentials) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(
+        "NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY is not defined. Using fallback chart data instead."
+      );
+    }
+
+    return {
+      nodes: fallbackChartData.nodes.map((node) => ({ ...node })),
+      links: fallbackChartData.links.map((link) => ({ ...link })),
+    };
+  }
+
   const [nodeRows, linkRows] = await Promise.all([
     fetchSupabase("nodes", { select: "name,group_type" }),
     fetchSupabase("links", { select: "source,target,type" }),

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -3,14 +3,19 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-if (!supabaseUrl) {
-  throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL environment variable');
+export const supabase =
+  supabaseUrl && supabaseAnonKey
+    ? createClient(supabaseUrl, supabaseAnonKey)
+    : null;
+
+export type SupabaseClient = NonNullable<typeof supabase>;
+
+export function requireSupabaseClient(): SupabaseClient {
+  if (!supabase) {
+    throw new Error(
+      'Supabase client has not been configured. Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+    );
+  }
+
+  return supabase;
 }
-
-if (!supabaseAnonKey) {
-  throw new Error('Missing NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable');
-}
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
-
-export type SupabaseClient = typeof supabase;


### PR DESCRIPTION
## Summary
- fall back to bundled chart data when Supabase env vars are missing
- guard Supabase client creation so the module no longer throws during import

## Testing
- npm run build *(fails: Next.js could not download Google Fonts in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4242a4f4c8327b5f453f2bcd74316