### PR TITLE
Add offline fallbacks for chart views

### DIFF
--- a/app/chart/page.jsx
+++ b/app/chart/page.jsx
@@ -3,11 +3,14 @@
 import { useEffect, useState } from "react";
 
 import ChartClient from "./ChartClient";
+import fallbackChart from "@/data/chart.json";
 import { supabase } from "@/lib/supabaseClient";
 import { buildChartData, EMPTY_CHART_DATA } from "@/lib/chartData";
 
 export default function ChartPage() {
   const [chartData, setChartData] = useState(EMPTY_CHART_DATA);
+  const [isUsingFallback, setIsUsingFallback] = useState(false);
+  const [fallbackMessage, setFallbackMessage] = useState("");
 
   useEffect(() => {
     let isActive = true;
@@ -30,15 +33,25 @@ export default function ChartPage() {
           console.error("Error fetching public links from Supabase:", linkError);
         }
 
+        if (nodeError || linkError) {
+          throw nodeError ?? linkError;
+        }
+
         if (!isActive) {
           return;
         }
 
         setChartData(buildChartData(nodeRows ?? [], linkRows ?? []));
+        setIsUsingFallback(false);
+        setFallbackMessage("");
       } catch (error) {
         console.error("Unexpected error fetching public chart data from Supabase:", error);
         if (isActive) {
-          setChartData(EMPTY_CHART_DATA);
+          setChartData(buildChartData(fallbackChart.nodes, fallbackChart.links));
+          setIsUsingFallback(true);
+          setFallbackMessage(
+            "Showing cached sample data while we reconnect to the live chart."
+          );
         }
       }
     }
@@ -58,6 +71,11 @@ export default function ChartPage() {
           Hover to highlight, click to inspect, and use the filters to explore the network.
         </p>
       </div>
+      {isUsingFallback && fallbackMessage ? (
+        <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-2 text-xs text-amber-200">
+          {fallbackMessage}
+        </div>
+      ) : null}
       <ChartClient data={chartData} />
     </div>
   );


### PR DESCRIPTION
## Summary
- add a Supabase failure fallback on the public chart that loads bundled demo data and surfaces a notice
- extend the private chart experience with localStorage caching/offline mode so data and additions work without Supabase

## Testing
- `npm run lint` *(fails: cannot download @eslint/eslintrc from npm registry due to restricted network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d4725efb9c8327a850c49742aea94f