### PR TITLE
Ensure personal chart shows connected user node

### DIFF
--- a/app/chart/ChartClient.jsx
+++ b/app/chart/ChartClient.jsx
@@ -9,6 +9,7 @@ const groupColors = {
   dating: "#c084fc",
   family: "#facc15",
   colleague: "#22d3ee",
+  self: "#fde68a",
 };
 
 function getGroupColor(group) {


### PR DESCRIPTION
## Summary
- ensure the personal chart data always includes a user node and migrate stored links to reference it
- connect locally added people to the user node and update persisted offline data accordingly
- add a distinct color for the self node in the force graph renderer

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd51327f288327b94b6a8e158194eb