### PR TITLE
Add Supabase API routes for chart data management

### DIFF
--- a/app/api/chart/personal/route.js
+++ b/app/api/chart/personal/route.js
@@ -1,9 +1,13 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createSupabaseRouteClient } from "@/lib/supabaseRouteClient";
 
 export async function GET() {
-  const supabase = createRouteHandlerClient({ cookies });
+  let supabase;
+  try {
+    supabase = createSupabaseRouteClient();
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
   const {
     data: { user },
     error: userError,

--- a/app/api/chart/personal/route.js
+++ b/app/api/chart/personal/route.js
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+
+export async function GET() {
+  const supabase = createRouteHandlerClient({ cookies });
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError) {
+    return NextResponse.json({ error: userError.message }, { status: 500 });
+  }
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const [{ data: nodes, error: nodesError }, { data: links, error: linksError }] = await Promise.all([
+    supabase
+      .from("nodes")
+      .select("id, name, group_type, user_id, is_base")
+      .eq("user_id", user.id),
+    supabase
+      .from("links")
+      .select("id, source, target, type, user_id")
+      .eq("user_id", user.id),
+  ]);
+
+  if (nodesError) {
+    return NextResponse.json({ error: nodesError.message }, { status: 500 });
+  }
+
+  if (linksError) {
+    return NextResponse.json({ error: linksError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ nodes: nodes ?? [], links: links ?? [] });
+}

--- a/app/api/chart/personal/route.js
+++ b/app/api/chart/personal/route.js
@@ -4,7 +4,7 @@ import { createSupabaseRouteClient } from "@/lib/supabaseRouteClient";
 export async function GET() {
   let supabase;
   try {
-    supabase = createSupabaseRouteClient();
+    supabase = await createSupabaseRouteClient();
   } catch (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/app/api/chart/public/route.js
+++ b/app/api/chart/public/route.js
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+
+export async function GET() {
+  const supabase = createRouteHandlerClient({ cookies });
+
+  const [{ data: nodes, error: nodesError }, { data: links, error: linksError }] = await Promise.all([
+    supabase.from("nodes").select("id, name, group_type, user_id, is_base"),
+    supabase.from("links").select("id, source, target, type, user_id"),
+  ]);
+
+  if (nodesError) {
+    return NextResponse.json({ error: nodesError.message }, { status: 500 });
+  }
+
+  if (linksError) {
+    return NextResponse.json({ error: linksError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ nodes: nodes ?? [], links: links ?? [] });
+}

--- a/app/api/chart/public/route.js
+++ b/app/api/chart/public/route.js
@@ -1,9 +1,13 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createSupabaseRouteClient } from "@/lib/supabaseRouteClient";
 
 export async function GET() {
-  const supabase = createRouteHandlerClient({ cookies });
+  let supabase;
+  try {
+    supabase = createSupabaseRouteClient();
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
 
   const [{ data: nodes, error: nodesError }, { data: links, error: linksError }] = await Promise.all([
     supabase.from("nodes").select("id, name, group_type, user_id, is_base"),

--- a/app/api/chart/public/route.js
+++ b/app/api/chart/public/route.js
@@ -4,7 +4,7 @@ import { createSupabaseRouteClient } from "@/lib/supabaseRouteClient";
 export async function GET() {
   let supabase;
   try {
-    supabase = createSupabaseRouteClient();
+    supabase = await createSupabaseRouteClient();
   } catch (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/app/api/links/route.js
+++ b/app/api/links/route.js
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createSupabaseRouteClient } from "@/lib/supabaseRouteClient";
 
 export async function POST(request) {
   const body = await request.json().catch(() => null);
@@ -9,7 +8,12 @@ export async function POST(request) {
     return NextResponse.json({ error: "Missing or invalid link payload" }, { status: 400 });
   }
 
-  const supabase = createRouteHandlerClient({ cookies });
+  let supabase;
+  try {
+    supabase = createSupabaseRouteClient();
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
   const {
     data: { user },
     error: userError,

--- a/app/api/links/route.js
+++ b/app/api/links/route.js
@@ -10,7 +10,7 @@ export async function POST(request) {
 
   let supabase;
   try {
-    supabase = createSupabaseRouteClient();
+    supabase = await createSupabaseRouteClient();
   } catch (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/app/api/links/route.js
+++ b/app/api/links/route.js
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+
+export async function POST(request) {
+  const body = await request.json().catch(() => null);
+
+  if (!body || typeof body.source !== "string" || typeof body.target !== "string" || typeof body.type !== "string") {
+    return NextResponse.json({ error: "Missing or invalid link payload" }, { status: 400 });
+  }
+
+  const supabase = createRouteHandlerClient({ cookies });
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError) {
+    return NextResponse.json({ error: userError.message }, { status: 500 });
+  }
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from("links")
+    .insert({
+      source: body.source,
+      target: body.target,
+      type: body.type,
+      user_id: user.id,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ link: data });
+}

--- a/app/api/nodes/route.js
+++ b/app/api/nodes/route.js
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createSupabaseRouteClient } from "@/lib/supabaseRouteClient";
 
 export async function POST(request) {
   const body = await request.json().catch(() => null);
@@ -9,7 +8,12 @@ export async function POST(request) {
     return NextResponse.json({ error: "Missing or invalid node payload" }, { status: 400 });
   }
 
-  const supabase = createRouteHandlerClient({ cookies });
+  let supabase;
+  try {
+    supabase = createSupabaseRouteClient();
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
   const {
     data: { user },
     error: userError,

--- a/app/api/nodes/route.js
+++ b/app/api/nodes/route.js
@@ -10,7 +10,7 @@ export async function POST(request) {
 
   let supabase;
   try {
-    supabase = createSupabaseRouteClient();
+    supabase = await createSupabaseRouteClient();
   } catch (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/app/api/nodes/route.js
+++ b/app/api/nodes/route.js
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+
+export async function POST(request) {
+  const body = await request.json().catch(() => null);
+
+  if (!body || typeof body.name !== "string" || typeof body.group_type !== "string") {
+    return NextResponse.json({ error: "Missing or invalid node payload" }, { status: 400 });
+  }
+
+  const supabase = createRouteHandlerClient({ cookies });
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError) {
+    return NextResponse.json({ error: userError.message }, { status: 500 });
+  }
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from("nodes")
+    .insert({
+      name: body.name,
+      group_type: body.group_type,
+      user_id: user.id,
+      is_base: body.is_base ?? false,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ node: data });
+}

--- a/lib/supabaseRouteClient.js
+++ b/lib/supabaseRouteClient.js
@@ -1,0 +1,35 @@
+import { cookies } from "next/headers";
+import { createServerClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+export function createSupabaseRouteClient() {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    throw new Error("Supabase environment variables are not configured.");
+  }
+
+  const cookieStore = cookies();
+
+  return createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      set(name, value, options) {
+        try {
+          cookieStore.set({ name, value, ...options });
+        } catch (error) {
+          console.error("Failed to set Supabase cookie", error);
+        }
+      },
+      remove(name, options) {
+        try {
+          cookieStore.delete({ name, ...options });
+        } catch (error) {
+          console.error("Failed to remove Supabase cookie", error);
+        }
+      },
+    },
+  });
+}

--- a/lib/supabaseRouteClient.js
+++ b/lib/supabaseRouteClient.js
@@ -1,35 +1,98 @@
 import { cookies } from "next/headers";
-import { createServerClient } from "@supabase/supabase-js";
+import { createClient } from "@supabase/supabase-js";
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-export function createSupabaseRouteClient() {
+const COOKIE_TOKEN_KEYS = [
+  "access_token",
+  "accessToken",
+  "access-token",
+];
+
+const COOKIE_REFRESH_KEYS = [
+  "refresh_token",
+  "refreshToken",
+  "refresh-token",
+];
+
+function getProjectRef(url) {
+  try {
+    const { hostname } = new URL(url);
+    return hostname.split(".")[0];
+  } catch (error) {
+    console.error("Failed to parse Supabase project ref", error);
+    return null;
+  }
+}
+
+function extractToken(candidate, possibleKeys) {
+  if (!candidate || typeof candidate !== "object") {
+    return null;
+  }
+
+  for (const key of possibleKeys) {
+    if (typeof candidate[key] === "string" && candidate[key]) {
+      return candidate[key];
+    }
+  }
+
+  return null;
+}
+
+function readSessionTokens(cookieValue) {
+  try {
+    const parsed = JSON.parse(cookieValue);
+    const candidates = [parsed, parsed?.currentSession, parsed?.session];
+
+    for (const candidate of candidates) {
+      const accessToken = extractToken(candidate, COOKIE_TOKEN_KEYS);
+      const refreshToken = extractToken(candidate, COOKIE_REFRESH_KEYS);
+
+      if (accessToken && refreshToken) {
+        return { accessToken, refreshToken };
+      }
+    }
+  } catch (error) {
+    console.error("Failed to parse Supabase auth cookie", error);
+  }
+
+  return { accessToken: null, refreshToken: null };
+}
+
+export async function createSupabaseRouteClient() {
   if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
     throw new Error("Supabase environment variables are not configured.");
   }
 
   const cookieStore = cookies();
-
-  return createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-    cookies: {
-      getAll() {
-        return cookieStore.getAll();
-      },
-      set(name, value, options) {
-        try {
-          cookieStore.set({ name, value, ...options });
-        } catch (error) {
-          console.error("Failed to set Supabase cookie", error);
-        }
-      },
-      remove(name, options) {
-        try {
-          cookieStore.delete({ name, ...options });
-        } catch (error) {
-          console.error("Failed to remove Supabase cookie", error);
-        }
-      },
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
     },
   });
+
+  const projectRef = getProjectRef(SUPABASE_URL);
+
+  if (projectRef) {
+    const authCookie = cookieStore.get(`sb-${projectRef}-auth-token`);
+
+    if (authCookie?.value) {
+      const { accessToken, refreshToken } = readSessionTokens(authCookie.value);
+
+      if (accessToken && refreshToken) {
+        const { error } = await supabase.auth.setSession({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+        });
+
+        if (error) {
+          console.error("Failed to restore Supabase session from cookies", error);
+        }
+      }
+    }
+  }
+
+  return supabase;
 }


### PR DESCRIPTION
## Summary
- add authenticated route for inserting nodes scoped to the logged-in user
- add authenticated route for inserting links scoped to the logged-in user
- expose public and personal chart fetch routes backed by Supabase

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd551fa4788327a46c5a82afb458c5