### PR TITLE
Fix public chart Supabase configuration fallback

### DIFF
--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,11 +1,8 @@
 import { createBrowserClient } from "@supabase/auth-helpers-nextjs";
 
-const DEFAULT_SUPABASE_URL = "https://iqafhqbiwpqpfridpgaq.supabase.co";
-const DEFAULT_SUPABASE_ANON_KEY =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlxYWZocWJpd3BxcGZyaWRwZ2FxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTg3MzIyMzYsImV4cCI6MjA3NDMwODIzNn0.e-bBVaqRRHhLN-7kYXNJjyBD-DgIUwlzOGnDEXDQzLQ";
+import { getSupabaseAnonKey, getSupabaseUrl } from "./supabaseConfig";
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? DEFAULT_SUPABASE_URL;
-const supabaseAnonKey =
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? DEFAULT_SUPABASE_ANON_KEY;
+const supabaseUrl = getSupabaseUrl();
+const supabaseAnonKey = getSupabaseAnonKey();
 
 export const supabase = createBrowserClient(supabaseUrl, supabaseAnonKey);

--- a/lib/supabaseConfig.js
+++ b/lib/supabaseConfig.js
@@ -1,0 +1,11 @@
+const DEFAULT_SUPABASE_URL = "https://iqafhqbiwpqpfridpgaq.supabase.co";
+const DEFAULT_SUPABASE_ANON_KEY =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlxYWZocWJpd3BxcGZyaWRwZ2FxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTg3MzIyMzYsImV4cCI6MjA3NDMwODIzNn0.e-bBVaqRRHhLN-7kYXNJjyBD-DgIUwlzOGnDEXDQzLQ";
+
+export function getSupabaseUrl() {
+  return process.env.NEXT_PUBLIC_SUPABASE_URL ?? DEFAULT_SUPABASE_URL;
+}
+
+export function getSupabaseAnonKey() {
+  return process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? DEFAULT_SUPABASE_ANON_KEY;
+}

--- a/lib/supabaseRouteClient.js
+++ b/lib/supabaseRouteClient.js
@@ -1,19 +1,17 @@
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+import { getSupabaseAnonKey, getSupabaseUrl } from "@/lib/supabaseConfig";
 
 export async function createSupabaseRouteClient() {
-  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-    throw new Error("Supabase environment variables are not configured.");
-  }
+  const supabaseUrl = getSupabaseUrl();
+  const supabaseKey = getSupabaseAnonKey();
 
   return createRouteHandlerClient(
     { cookies },
     {
-      supabaseUrl: SUPABASE_URL,
-      supabaseKey: SUPABASE_ANON_KEY,
+      supabaseUrl,
+      supabaseKey,
     },
   );
 }


### PR DESCRIPTION
## Summary
- add a shared Supabase configuration helper that exposes default URL and anon key values
- update the browser and route Supabase clients to use the shared helper so the public chart no longer falls back to static data when env vars are missing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd5e8b39a88327adb1938e076f4eb6