### PR TITLE
Fix public chart to use Supabase data

### DIFF
--- a/app/api/chart/public/route.js
+++ b/app/api/chart/public/route.js
@@ -1,17 +1,32 @@
 import { NextResponse } from "next/server";
 import { createSupabaseRouteClient } from "@/lib/supabaseRouteClient";
+import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
+
+export const dynamic = "force-dynamic";
 
 export async function GET() {
   let supabase;
   try {
-    supabase = await createSupabaseRouteClient();
-  } catch (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    supabase = createSupabaseServiceClient();
+  } catch (serviceClientError) {
+    try {
+      supabase = await createSupabaseRouteClient();
+    } catch (routeClientError) {
+      const error =
+        serviceClientError instanceof Error ? serviceClientError : routeClientError;
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
   }
 
   const [{ data: nodes, error: nodesError }, { data: links, error: linksError }] = await Promise.all([
-    supabase.from("nodes").select("id, name, group_type, user_id, is_base"),
-    supabase.from("links").select("id, source, target, type, user_id"),
+    supabase
+      .from("nodes")
+      .select("id, name, group_type, user_id, is_base")
+      .eq("is_base", true),
+    supabase
+      .from("links")
+      .select("id, source, target, type, user_id")
+      .is("user_id", null),
   ]);
 
   if (nodesError) {

--- a/lib/supabaseConfig.js
+++ b/lib/supabaseConfig.js
@@ -9,3 +9,15 @@ export function getSupabaseUrl() {
 export function getSupabaseAnonKey() {
   return process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? DEFAULT_SUPABASE_ANON_KEY;
 }
+
+export function getSupabaseServiceRoleKey() {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!serviceRoleKey) {
+    throw new Error(
+      "Missing SUPABASE_SERVICE_ROLE_KEY environment variable required for server-side Supabase access.",
+    );
+  }
+
+  return serviceRoleKey;
+}

--- a/lib/supabaseServiceClient.js
+++ b/lib/supabaseServiceClient.js
@@ -1,0 +1,15 @@
+import { createClient } from "@supabase/supabase-js";
+
+import { getSupabaseServiceRoleKey, getSupabaseUrl } from "@/lib/supabaseConfig";
+
+export function createSupabaseServiceClient() {
+  const supabaseUrl = getSupabaseUrl();
+  const serviceRoleKey = getSupabaseServiceRoleKey();
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add a Supabase service-role client for server-only access
- update the public chart API route to use live Supabase data and avoid caching
- limit the public response to base nodes and anonymous links

## Testing
- npm run lint *(fails: npm is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5fc588408327a73f209f5d8bd1d5