### PR TITLE
Add read-only Supabase fallback for public chart API

### DIFF
--- a/app/api/chart/public/route.js
+++ b/app/api/chart/public/route.js
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { createSupabaseRouteClient } from "@/lib/supabaseRouteClient";
+import { createSupabaseReadOnlyClient } from "@/lib/supabaseReadOnlyClient";
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
 
 export const dynamic = "force-dynamic";
@@ -10,10 +10,10 @@ export async function GET() {
     supabase = createSupabaseServiceClient();
   } catch (serviceClientError) {
     try {
-      supabase = await createSupabaseRouteClient();
-    } catch (routeClientError) {
+      supabase = createSupabaseReadOnlyClient();
+    } catch (readOnlyClientError) {
       const error =
-        serviceClientError instanceof Error ? serviceClientError : routeClientError;
+        serviceClientError instanceof Error ? serviceClientError : readOnlyClientError;
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
   }

--- a/lib/supabaseReadOnlyClient.js
+++ b/lib/supabaseReadOnlyClient.js
@@ -1,0 +1,15 @@
+import { createClient } from "@supabase/supabase-js";
+
+import { getSupabaseAnonKey, getSupabaseUrl } from "@/lib/supabaseConfig";
+
+export function createSupabaseReadOnlyClient() {
+  const supabaseUrl = getSupabaseUrl();
+  const anonKey = getSupabaseAnonKey();
+
+  return createClient(supabaseUrl, anonKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- fall back to a read-only Supabase client when the service key is unavailable in the public chart API
- add a helper that builds a Supabase client using the anon key for read-only access

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd61b3dcc88327ae06c57a764cb236