### PR TITLE
Fix Supabase config to respect server env vars

### DIFF
--- a/lib/supabaseConfig.js
+++ b/lib/supabaseConfig.js
@@ -3,11 +3,19 @@ const DEFAULT_SUPABASE_ANON_KEY =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlxYWZocWJpd3BxcGZyaWRwZ2FxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTg3MzIyMzYsImV4cCI6MjA3NDMwODIzNn0.e-bBVaqRRHhLN-7kYXNJjyBD-DgIUwlzOGnDEXDQzLQ";
 
 export function getSupabaseUrl() {
-  return process.env.NEXT_PUBLIC_SUPABASE_URL ?? DEFAULT_SUPABASE_URL;
+  return (
+    process.env.NEXT_PUBLIC_SUPABASE_URL ??
+    process.env.SUPABASE_URL ??
+    DEFAULT_SUPABASE_URL
+  );
 }
 
 export function getSupabaseAnonKey() {
-  return process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? DEFAULT_SUPABASE_ANON_KEY;
+  return (
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+    process.env.SUPABASE_ANON_KEY ??
+    DEFAULT_SUPABASE_ANON_KEY
+  );
 }
 
 export function getSupabaseServiceRoleKey() {


### PR DESCRIPTION
## Summary
- allow Supabase configuration helpers to read server-only SUPABASE_URL and SUPABASE_ANON_KEY values before falling back to defaults
- ensure the public chart API can connect to the live database even when only server-side environment variables are present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de7ba1e19c83279e850888f8c8a0f1